### PR TITLE
fix: invalid loggerName

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.batch.escalog</groupId>
     <artifactId>escalog</artifactId>
-    <version>1.1.4-KLARRIO</version>
+    <version>1.1.4-0.1.0-SNAPSHOT</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -57,7 +57,7 @@
             <plugin>
                 <groupId>org.jfrog.buildinfo</groupId>
                 <artifactId>artifactory-maven-plugin</artifactId>
-                <version>2.6.1</version>
+                <version>2.2.1</version>
                 <inherited>false</inherited>
                 <executions>
                     <execution>

--- a/src/main/java/com/batch/escalog/LogFmtLayout.java
+++ b/src/main/java/com/batch/escalog/LogFmtLayout.java
@@ -78,11 +78,11 @@ public class LogFmtLayout extends LayoutBase<ILoggingEvent>
         appenders.put(MESSAGE.toString(),   this::msgAppender);
         appenders.put(TNAME.toString(),     this::threadAppender);
         appenders.put(EXCEPTION.toString(), this::errorAppender);
-        appenders.put(LOGGER.toString(),    this::classAppender);
-        appenders.put("custom",             this::customFieldsAppender);
+        appenders.put(LOGGER.toString(),    this::loggerAppender);
+        appenders.put("custom",          this::customFieldsAppender);
 
         this.defaultAppenders = new ArrayList<>(Arrays.asList(
-            this::timeAppender, this::levelAppender,this::threadAppender, this::classAppender, this::msgAppender, this::errorAppender, this::customFieldsAppender
+            this::timeAppender, this::levelAppender,this::threadAppender, this::loggerAppender, this::msgAppender, this::errorAppender, this::customFieldsAppender
         ));
     }
 
@@ -150,6 +150,10 @@ public class LogFmtLayout extends LayoutBase<ILoggingEvent>
         return sb.toString();
     }
 
+    private void loggerAppender(StringBuilder sb, ILoggingEvent iLoggingEvent)
+    {
+        appendKeyValueAndEscape(sb, LOGGER.toString(), iLoggingEvent.getLoggerName());
+    }
 
     private void levelAppender(StringBuilder sb, ILoggingEvent iLoggingEvent)
     {

--- a/src/test/java/com/batch/escalog/LogFmtLayoutTest.java
+++ b/src/test/java/com/batch/escalog/LogFmtLayoutTest.java
@@ -54,7 +54,7 @@ public class LogFmtLayoutTest
 
 
         assertEquals(
-            "prefix=\"prefix\" pname=escalog time=\"2017-11-30T15:10:25.123Z\" level=debug tname=thread0 msg=\"message with \\\"double quotes\\\"\" key1=value1 key2=\"val ue2\"\n",
+            "prefix=\"prefix\" pname=escalog time=\"2017-11-30T15:10:25.123Z\" level=debug tname=thread0 logger=loggerName msg=\"message with \\\"double quotes\\\"\" key1=value1 key2=\"val ue2\"\n",
             logFmtLayout.doLayout(loggingEvent)
         );
 
@@ -81,7 +81,7 @@ public class LogFmtLayoutTest
 
 
         assertEquals(
-                "prefix=\"prefix\" pname=escalog time=\"2017-11-30T11:10:25.123Z\" level=debug tname=thread0 msg=\"message with \\\"double quotes\\\"\" key1=value1 key2=\"val ue2\"\n",
+                "prefix=\"prefix\" pname=escalog time=\"2017-11-30T11:10:25.123Z\" level=debug tname=thread0 logger=loggerName msg=\"message with \\\"double quotes\\\"\" key1=value1 key2=\"val ue2\"\n",
                 logFmtLayout.doLayout(loggingEvent)
         );
 


### PR DESCRIPTION
@twuyts this should fix the issue you have seen in the prov-lib
JIRA: https://klarrio.atlassian.net/browse/KDN-2183


when running the previous version of escalog in the prov-lib unit tests:
```
pname=prov-generic time="2020-11-24T17:49:11.233Z" level=info tname=pool-1-thread-1-ScalaTest-running-ResourceProvisionerTest logger=com.klarrio.nicodemus.prov.Provisioner msg="[666] remove allocation/dummy-tenant/volume/dummy-volume from Actual"
```
Running the same unit-tests with escalog from this branch:
```
pname=prov-generic time="2020-11-24T17:52:35.087Z" level=info tname=pool-1-thread-1-ScalaTest-running-ResourceProvisionerTest logger="com.klarrio.nicodemus.prov.provisioners.ResourceProvisionerTest$DummyVolumeProvisioner" msg="[666] remove allocation/dummy-tenant/volume/dummy-volume from Actual"
```